### PR TITLE
[REVIEW] - [NA-000] - Bucket to Indexer Multi Env

### DIFF
--- a/terraspace/app/modules/lambda-from-s3/auth.tf
+++ b/terraspace/app/modules/lambda-from-s3/auth.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "lambda_function_lambda_role" {
-  name = "lambda-function-lambda-role"
+  name = "${var.lambda.name}_role"
 
   assume_role_policy = <<EOF
 {

--- a/terraspace/app/modules/lambda-from-s3/log.tf
+++ b/terraspace/app/modules/lambda-from-s3/log.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_log_group" "lambda-function_log_group" {
 }
 
 resource "aws_iam_policy" "lambda_logging" {
-  name        = "lambda_logging"
+  name        = "${var.lambda.name}_lambda_logging"
   path        = "/"
   description = "IAM policy for logging from a lambda"
 

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/main.tf
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/main.tf
@@ -41,5 +41,8 @@ module "lambda_from_s3" {
 }
 
 resource "aws_ecr_repository" "ecr_repo_bucket_to_indexer_lambda" {
-  name = "bucket-to-indexer-lambda"
+  name = var.ecr_repository_name
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 }

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/base.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/base.tfvars
@@ -5,6 +5,7 @@ lambda = {
 }
 
 
-node_env              = "<%= expansion(':ENV') %>"
-indexing_stack_region = "us-west-2"
-ecr_repository_name   = "<%= expansion(':ENV') %>-ep-bucket-to-indexer-lambda"
+node_env                               = "<%= expansion(':ENV') %>"
+indexing_stack_region                  = "us-west-2"
+ecr_repository_name                    = "<%= expansion(':ENV') %>-ep-bucket-to-indexer-lambda"
+bucket_to_indexer_lambda_image_version = "latest"

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/base.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/base.tfvars
@@ -1,8 +1,10 @@
 lambda = {
-  name        = "bucket-to-indexer"
+  name        = "<%= expansion(':ENV') %>-ep-bucket-to-indexer"
   memory_size = 1024
   timeout     = 900
 }
 
+
 node_env              = "<%= expansion(':ENV') %>"
 indexing_stack_region = "us-west-2"
+ecr_repository_name   = "<%= expansion(':ENV') %>-ep-bucket-to-indexer-lambda"

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/base.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/base.tfvars
@@ -1,8 +1,0 @@
-bucket = (
-  {
-    bucket = "dotstorage-prod-0"
-    arn    = "arn:aws:s3:::dotstorage-prod-0"
-    id     = "dotstorage-prod-0"
-  }
-)
-

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/dev.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/dev.tfvars
@@ -6,3 +6,4 @@ bucket = (
     id     = "dotstorage-dev-0"
   }
 )
+bucket_to_indexer_lambda_image_version = "dev"

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/dev.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/dev.tfvars
@@ -1,0 +1,8 @@
+node_env = "dev"
+bucket = (
+  {
+    bucket = "dotstorage-dev-0"
+    arn    = "arn:aws:s3:::dotstorage-dev-0"
+    id     = "dotstorage-dev-0"
+  }
+)

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/prod.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/prod.tfvars
@@ -1,1 +1,14 @@
 node_env = "production"
+lambda = {
+  name        = "bucket-to-indexer"
+  memory_size = 1024
+  timeout     = 900
+}
+bucket = (
+  {
+    bucket = "dotstorage-prod-0"
+    arn    = "arn:aws:s3:::dotstorage-prod-0"
+    id     = "dotstorage-prod-0"
+  }
+)
+ecr_repository_name = "bucket-to-indexer-lambda"

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/staging.tfvars
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/tfvars/us-east-2/staging.tfvars
@@ -1,0 +1,8 @@
+node_env = "staging"
+bucket = (
+  {
+    bucket = "dotstorage-staging-0"
+    arn    = "arn:aws:s3:::dotstorage-staging-0"
+    id     = "dotstorage-staging-0"
+  }
+)

--- a/terraspace/app/stacks/bucket-to-indexer-lambda/variables.tf
+++ b/terraspace/app/stacks/bucket-to-indexer-lambda/variables.tf
@@ -27,6 +27,11 @@ variable "indexing_stack_region" {
   description = "Region which indexer is deployed to"
 }
 
+variable "ecr_repository_name" {
+  type        = string
+  description = "Name for ECR repo. We use this repo to store bucket-to-indexer lambda docker image"
+}
+
 variable "bucket_to_indexer_lambda_image_version" {
   type        = string
   default     = "latest"


### PR DESCRIPTION
- Allows Terraspace to create multiple bucket-to-indexer based on environment/region layers (https://terraspace.cloud/docs/layering/)

I've already created the resources using these commands:

`AWS_REGION=us-east-2 TS_ENV=dev terraspace up bucket-to-indexer-lambda`
`AWS_REGION=us-east-2 TS_ENV=staging terraspace up bucket-to-indexer-lambda`
