### PR TITLE
[REVIEW] - [NA-000] -  Reuse policy to avoid 10 policies per role limit

### DIFF
--- a/terraspace/app/stacks/indexing/auth.tf
+++ b/terraspace/app/stacks/indexing/auth.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_policy" "sqs_indexer_policy_receive" {
   name        = var.sqs_indexer_policy_receive_name
-  description = "Policy for allowing publish messages in SQS"
+  description = "Policy for allowing receiving messages from SQS"
   policy      = <<EOF
 {
     "Version": "2012-10-17",
@@ -14,19 +14,7 @@ resource "aws_iam_policy" "sqs_indexer_policy_receive" {
             "Effect": "Allow",
             "Action": "sqs:GetQueueAttributes",
             "Resource": "${aws_sqs_queue.indexer_topic.arn}"
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "sqs_indexer_policy_delete" {
-  name        = var.sqs_indexer_policy_delete_name
-  description = "Policy for allowing publish messages in SQS"
-  policy      = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
+        },
         {
             "Effect": "Allow",
             "Action": "sqs:DeleteMessage",

--- a/terraspace/app/stacks/indexing/main.tf
+++ b/terraspace/app/stacks/indexing/main.tf
@@ -31,7 +31,6 @@ module "indexer_lambda_from_sqs" {
       var.shared_stack_sqs_multihashes_policy_send,
       var.shared_stack_s3_dotstorage_policy_read,
       aws_iam_policy.sqs_indexer_policy_receive,
-      aws_iam_policy.sqs_indexer_policy_delete,
       aws_iam_policy.sqs_notifications_policy_send,
     ]
   }


### PR DESCRIPTION
Indexer_roles's have reached the 10 policies per role limit.

- I've requested the increase: https://us-east-1.console.aws.amazon.com/support/home?region=us-east-1&skipRegion=true#/case/?displayId=10337767901&language=en
- It makes sense for the component that has the ability to read the message also to be able to remove it from queue, so we can use one less policy
